### PR TITLE
Clocks

### DIFF
--- a/demos/try_input.py
+++ b/demos/try_input.py
@@ -4,7 +4,7 @@ from toon.input import Mouse
 from toon.input import Keyboard
 from toon.input import Hand
 from toon.input.fake import FakeInput
-from timeit import default_timer
+from toon.input.clock import mono_clock
 import numpy as np
 import ctypes
 # import matplotlib.pyplot as plt
@@ -16,17 +16,17 @@ if os.name == 'nt':
 np.set_printoptions(precision=5, suppress=True)
 
 if __name__ == '__main__':
-    dev = MpI(Mouse)
+    default_timer = mono_clock.get_time
+    dev = MpI(Mouse, clock=default_timer)
     # dev = MpI(Keyboard, keys=['a', 's', 'd', 'f'])
     # dev = MpI(Hand)
     # dev = MpI(ForceTransducers)
     # dev = MpI(FakeInput, sampling_frequency=1000, data_shape=[[5]], data_type=[ctypes.c_double])
-
     read_times = []
     diffs = []
     with dev as d:
         t0 = default_timer()
-        t1 = t0 + 30
+        t1 = t0 + 10
         t2 = 0
         while default_timer() < t1:
             t0 = default_timer()
@@ -34,7 +34,8 @@ if __name__ == '__main__':
             t3 = default_timer()
             read_times.append(t3 - t0)
             if time is not None:
-                print(data)
+                print('Frame time: ' + str(t0))
+                print(time)
                 diffs.extend(np.diff(time))
             while default_timer() < t2:
                 pass

--- a/docs/input.md
+++ b/docs/input.md
@@ -27,7 +27,7 @@ with dev as d:
 There are four methods necessary for a complete device (and enforced via the `abc` module).
 
 - `__init__()`
-  - Can specify a different clock source here (via the `clock` keyword argument). The default `timeit.default_timer` is pretty good, but I *suspect* `psychopy.clock.monotonicClock.getTime` might be better on Windows (untested, but a peek at the source suggests they're both based around `QueryPerformanceCounter`).
+  - Can specify a different clock source here (via the `clock` keyword argument). I've borrowed `psychopy`'s `clock.MontonicClock` (minus the pyglet import) to use as the default.
   - Pass in other keyword args too, like sampling frequency, various device-specific flags, etc.
 - `__enter__()`
   - Start communication with the device here.

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
 
 setup(
     name='toon',
-    version='0.8.1',
+    version='0.8.2',
     description='Tools for neuroscience experiments',
     url='https://github.com/aforren1/toon',
     author='Alexander Forrence',

--- a/toon/input/base_input.py
+++ b/toon/input/base_input.py
@@ -9,7 +9,7 @@ class BaseInput():
     def __init__(self, clock=mono_clock.get_time, **kwargs):
         """
         Args:
-            clock: A function that returns the current time. Defaults to :obj:`timeit.default_timer`.
+            clock: A function that returns the current time. Defaults to :obj:`toon.input.clock.mono_clock.get_time`.
             **kwargs: Device-specific keyword arguments. These can also be used to infer the sampling frequency,
                 shape of the data, and type of data.
         """

--- a/toon/input/base_input.py
+++ b/toon/input/base_input.py
@@ -1,13 +1,12 @@
 import abc
 import six
-from timeit import default_timer
-
+from toon.input.clock import mono_clock
 
 @six.add_metaclass(abc.ABCMeta)
 class BaseInput():
     """Abstract base class for input devices."""
     @abc.abstractmethod
-    def __init__(self, clock=default_timer, **kwargs):
+    def __init__(self, clock=mono_clock.get_time, **kwargs):
         """
         Args:
             clock: A function that returns the current time. Defaults to :obj:`timeit.default_timer`.

--- a/toon/input/clock.py
+++ b/toon/input/clock.py
@@ -1,0 +1,38 @@
+import os
+
+if os.name is 'nt':
+    from ctypes import byref, c_int64, windll
+    _fcounter = c_int64()
+    _qpfreq = c_int64()
+    windll.Kernel32.QueryPerformanceFrequency(byref(_qpfreq))
+    _qpfreq = float(_qpfreq.value)
+    _winQPC = windll.Kernel32.QueryPerformanceCounter
+
+    def get_time():
+        _winQPC(byref(_fcounter))
+        return _fcounter.value / _qpfreq
+else:
+    from timeit import default_timer as get_time
+
+class MonoClock(object):
+    """A stripped-down version of psychopy's clock.MonotonicClock.
+
+    I wanted to avoid importing pyglet on the remote process, in case that causes any headache.
+    """
+    def __init__(self, start_time=None):
+        super(MonoClock, self).__init__()
+        if not start_time:
+            # this is sub-millisec timer in python
+            self._start_time = get_time()
+        else:
+            self._start_time = start_time
+    def get_time(self):
+        """Returns the current time on this clock in secs (sub-ms precision)
+        """
+        return get_time() - self._start_time
+    @property
+    def start_time(self):
+        return self._start_time
+
+mono_clock = MonoClock()
+    


### PR DESCRIPTION
Replace `timeit.default_timer` with a stripped-down version of psychopy's `clock.MonotonicClock`, which allows us to share an origin time across processes.