### PR TITLE
0.9.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
 
 setup(
     name='toon',
-    version='0.9.0',
+    version='0.9.1',
     description='Tools for neuroscience experiments',
     url='https://github.com/aforren1/toon',
     author='Alexander Forrence',

--- a/toon/input/mp_input.py
+++ b/toon/input/mp_input.py
@@ -8,7 +8,8 @@ from toon.input.helper import check_and_fix_dims, shared_to_numpy
 
 
 class MultiprocessInput(object):
-    def __init__(self, device=None, high_priority=True, use_gc=False,
+    def __init__(self, device=None,
+                 high_priority=True, use_gc=False,
                  nrow=None, **kwargs):
         """
         Args:
@@ -133,6 +134,12 @@ class MultiprocessInput(object):
                 self.ps_process.nice(self.original_nice)
         except (psutil.AccessDenied, psutil.NoSuchProcess):
             pass
+
+    def __enter__(self):
+        self.start()
+
+    def __exit__(self):
+        self.stop()
 
 
 def worker(device, device_args, shared_lock, remote_ready,


### PR DESCRIPTION
This should soften the deprecation of the context-manager-based `MultiprocessInput`, allowing both formulations (though I think I still prefer the newer formulation for ease of dropping into existing experiments). 